### PR TITLE
Add "mg" to list.txt

### DIFF
--- a/list.txt
+++ b/list.txt
@@ -163,6 +163,7 @@ maps
 media
 message
 messages
+mg
 misc
 mms
 mobile


### PR DESCRIPTION
Mailgun (transactional email service) suggests to use the subdomain "mg.example.com" on setup of custom domains